### PR TITLE
KM-21 [Productivites] [FE] Missing member when change sprint

### DIFF
--- a/src/components/SelectSprint.js
+++ b/src/components/SelectSprint.js
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Select from '@material-ui/core/Select';
 import { KPIStoreContext } from '../contexts/KPIStore';
-import { dateFormat } from '../utils/TimeFormat';
 
 export default function SelectSprint({...props}) {
   const { boardSprints: [boardSprints] } = useContext(KPIStoreContext);
@@ -17,8 +16,7 @@ export default function SelectSprint({...props}) {
       {...props}
     >
       {boardSprints.map((item, idx) => {
-        const sprint_name = `sprint_${dateFormat(new Date(item.start_date), '_')} ~ sprint_${dateFormat(new Date(item.end_date), '_')}`;
-        return <option key={idx} value={item.id}>{item.name}</option>
+        return <option key={idx} value={item.id}>{`${item.name} - ${item.state}`}</option>
       })}
     </Select>
   );

--- a/src/pages/Productivities/ProductiveSection.js
+++ b/src/pages/Productivities/ProductiveSection.js
@@ -21,7 +21,7 @@ export default function ProductiveSection({...props}) {
       dispatchProductive({type: 'REMOVE_PRODUCTIVE', target_sprint_id: sprint_id})
     }
 
-    if( productiveData.length === 0 || prevReloadState.current !== reload) {
+    if( isEmptyData(jira_ids, productiveData) || prevReloadState.current !== reload ) {
       let promises = user_ids.map(item => {
         return GetProductivity(item, sprint_id, { cancelToken: source.token }).then(results => {
           const productivity = results.data;
@@ -47,9 +47,13 @@ export default function ProductiveSection({...props}) {
 
   return (
     <Paper style={{marginBottom: '1rem'}}>
-      <ProductiveTable data={productiveData.length !== 0 ? productiveData : undefined} />
+      <ProductiveTable data={isEmptyData(jira_ids, productiveData) ? undefined : productiveData} />
     </Paper>
   )
+}
+
+const isEmptyData = (jira_ids, productiveData) => {
+  return productiveData.length === 0 || ( jira_ids.length !== productiveData.length )
 }
 
 const getProductiveTable = (data, jira_ids, target_sprint_id) => {


### PR DESCRIPTION
* Fix Missing member when change sprint
* Adjust sprint list to show "[sprint_name] - [sprint_state]"
#### Reproduce
 * clear local storage or incognito browser
 * go to "/users"
 * click to open 1 user (anyone)
 * go to "/productivities"